### PR TITLE
correct ins file generation

### DIFF
--- a/src/lake_calibrator/functions.py
+++ b/src/lake_calibrator/functions.py
@@ -34,7 +34,6 @@ def parse_observation_file(file, start, end, max_depth=False):
     df["depth"] = df['depth'].abs()
     if max_depth:
         df = df[df['depth'] <= max_depth]
-    df = df.dropna()
     if len(df) == 0:
         raise ValueError("No valid observations available")
     return df

--- a/src/lake_calibrator/pest_calibrate.py
+++ b/src/lake_calibrator/pest_calibrate.py
@@ -223,13 +223,16 @@ def write_pest_ins_file(calibration_folder, calibration_options, simulation, obs
                                     row = df_t[df_t['depth'] == d].iloc[0]
                                 else:
                                     row = df_t
-                                strf = strf + ' @,@ !%s_%d_%d!' % (objective_variable[0], i, j)
-                                combined_observations.append({
-                                    'id': f"{objective_variable[0]}_{i}_{j}",
-                                    'value': row["value"],
-                                    'weight': row["weight"],
-                                    'group': objective_variable
-                                })
+                                if np.isnan(row["value"]):
+                                    strf = strf + ' @,@'
+                                else:
+                                    strf = strf + ' @,@ !%s_%d_%d!' % (objective_variable[0], i, j)
+                                    combined_observations.append({
+                                        'id': f"{objective_variable[0]}_{i}_{j}",
+                                        'value': row["value"],
+                                        'weight': row["weight"],
+                                        'group': objective_variable
+                                    })
                             else:
                                 strf = strf + ' @,@'
                         if len(strf) > 2000:


### PR DESCRIPTION
this corrects a bug in the generation of the instruction files.

The instruction files all need the exact same number of depths and times because the model output does as well. Until now, lines with only nan's were omitted which created wrong calibration results if more than one variable were calibrated and not all measurements were available on exactly the same dates.